### PR TITLE
Clarify that changing a Lastschrift requires cancellation and recreation

### DIFF
--- a/froide_payment/locale/de/LC_MESSAGES/django.po
+++ b/froide_payment/locale/de/LC_MESSAGES/django.po
@@ -277,7 +277,7 @@ msgstr "Sie können Ihren Dauerauftrag nur bei Ihrer Bank selbst abstellen."
 
 #: froide_payment/provider/lastschrift.py
 msgid "You can cancel your direct debit subscription here."
-msgstr "Sie können Ihre Dauerspende per Lastschrift hier kündigen."
+msgstr "Sie können Ihre Dauerspende per Lastschrift hier kündigen. Zum Ändern des Betrags kündigen Sie ihre Spende bitte und legen eine neue Dauerspende an."
 
 #: froide_payment/provider/paypal.py
 msgid "You can cancel your Paypal subscription."


### PR DESCRIPTION
This is currently only explained on the page to create a new subscription, but if you don't know you need to cancel the old one and make a new one, you are unlikely to try to create a new subscription when you want to change the existing one.